### PR TITLE
change for fixing CVE-2016-10599

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "sauce-connect",
   "keywords": ["selenium", "selenese", "browser-automation", "sauce", "saucelabs", "sauce-labs"],
   "version": "0.1.1",
-  "sauce-connect-url": "http://saucelabs.com/downloads/Sauce-Connect-latest.zip",
+  /*change for fixing CVE-2016-10599*/
+  "sauce-connect-url": "https://saucelabs.com/downloads/Sauce-Connect-latest.zip",
   "description": "Node.js wrapper over the SauceLabs SauceConnect.jar program for establishing a secure tunnel for intranet testing",
   "main": "lib/sauce-connect.coffee",
   "dependencies": {},


### PR DESCRIPTION
change for fixing CVE-2016-10599. download using secure protocol instead of plain http.